### PR TITLE
Update to Manifest for building the PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.md
 include LICENSE
 include RUINS_logo_small.png
 graft explainer
+prune data


### PR DESCRIPTION
This is a small change to the `MANIFEST.in`, which builds the package before being sent to PyPI.
Right now, the package would include the `./data` folder as well. As python packages are gzipped on PyPI, this would account for ~30MB in package size. More important: The package would technically distribute all the data in the folder which might have implications for the data licensing.

With this PR, the data folder is pruned on the packaging, meaning that **no data** will be distributed alongside the python package. From a package-size and licensing perspective, this might seem more desirable, but this also means we need to explain how to obtain the data and where to put it in a future installation guide.

For version 0.2 I did prune the data first, so as of now, no data was distributed via PyPI.

@cojacoo, it's up to you, either accept this PR, which will prune the data or close the PR without merging to add the data to the python package in the future.