### PR TITLE
Add csv source

### DIFF
--- a/ruins/core/__init__.py
+++ b/ruins/core/__init__.py
@@ -1,0 +1,1 @@
+from .config import Config

--- a/ruins/core/__init__.py
+++ b/ruins/core/__init__.py
@@ -1,1 +1,2 @@
 from .config import Config
+from .data_manager import DataManager

--- a/ruins/core/config.py
+++ b/ruins/core/config.py
@@ -30,8 +30,23 @@ class Config(Mapping):
         self.basepath = os.path.abspath(pjoin(os.path.dirname(__file__), '..', '..'))
         self.datapath = pjoin(self.basepath, 'data')
 
+        # mime readers
+        self.default_sources = {
+            'nc': 'HDF5Source',
+            'csv': 'CSVSource',
+        }
+        self.default_sources.update(kwargs.get('include_mimes', {}))
+
+        # reader args
+        self.sources_args = {
+            'stats.csv': dict(index_col=0),
+            'hsim_collect.csv': dict(index_col=0),
+            'windpowerx.csv': dict(index_col=0),
+        }
+        self.sources_args.update(kwargs.get('include_args', {}))
+
         # store the keys
-        self._keys = ['debug', 'basepath', 'datapath']
+        self._keys = ['debug', 'basepath', 'datapath', 'default_sources', 'source_args']
 
         # check if a path was provided
         conf_args = self.from_json(path) if path else {}

--- a/ruins/core/data_manager.py
+++ b/ruins/core/data_manager.py
@@ -66,17 +66,16 @@ class HDF5Source(DataSource):
         self.path = path
         self.cache = cache
 
-        # check cache settings
-        if self.cache:
-            self.data = self._load_source()
-
     def _load_source(self):
         """Method to load the actual source on the disk"""
         return xr.load_dataset(self.path)
 
     def read(self):
         if self.cache:
+            if not hasattr(self, 'data'):
+                self.data = self._load_source()
             return self.data
+
         else:
             return self._load_source()
     

--- a/ruins/core/data_manager.py
+++ b/ruins/core/data_manager.py
@@ -1,0 +1,230 @@
+"""
+Data Manager
+============
+
+The DataManager is a wrapper around all data sources used by RUINSapp.
+It can be configures by any :class:`Config <ruins.core.config.Config>` class
+and organizes or caches all data sources using a 
+:class:`DataSource <ruins.core.data_manager.DataSource>` inherited class.
+This makes the read and filter interface available on all sources, no matter
+where they are stored.
+Using the :class:`Config <ruins.core.config.Config>` to instantiate a data
+manager can in principle enabled different profiles, or even an interaction
+with the frontend, although not implemented nor desired at the current stage.
+
+Example
+-------
+
+.. code-block:: python
+
+    from ruins import core
+
+    # create default config
+    conf = core.Config()
+
+    # create a data manager from this
+    dm = core.DataManager(**conf)
+
+Of course, the data manager can also be used without the config, ie. to open it
+in debug mode:
+
+.. code-block:: python
+    
+    # using conf with conf.debug=False and overwrite it
+    dm = core.DataManager(**conf, debug=True)
+
+"""
+import abc
+import os
+import glob
+import xarray as xr
+from collections.abc import Mapping
+from typing import Type, List
+
+
+DEFAULT_MIMES = {
+    'nc': 'HDF5Source'
+}
+
+
+class DataSource(abc.ABC):
+    def __init__(self, **kwargs):
+        self._kwargs = kwargs
+
+    @abc.abstractmethod
+    def read(self):
+        pass
+    
+    @abc.abstractmethod
+    def filter(self, **kwargs):
+        pass
+
+
+class HDF5Source(DataSource):
+    def __init__(self, path: str, cache: bool = True, **kwargs):
+        super().__init__(**kwargs)
+        self.path = path
+        self.cache = cache
+
+        # check cache settings
+        if self.cache:
+            self.data = self._load_source()
+
+    def _load_source(self):
+        """Method to load the actual source on the disk"""
+        return xr.load_dataset(self.path)
+
+    def read(self):
+        if self.cache:
+            return self.data
+        else:
+            return self._load_source()
+    
+    def filter(self):
+        pass
+
+
+class DataManager(Mapping):
+    """Main class for accessing different data sources.
+
+    The DataManager holds and manages all data sources. The default behavior is
+    to scan the specified path for files of known file extension and cache them
+    in memory.
+
+    Parameters
+    ----------
+    datapath : str
+        A location where the data is stored. The class will load all sources 
+        there and make them accessible through DataSource classes.
+    cache : bool
+        Will be passed to the DataSource classes. It true, the source will only
+        be read once and then stored in memory until the DataManager gets
+        deconstructed.
+    include_mimes : dict
+        A dictionary of file extensions and their corresponding DataSource.
+        If something is not listed, the DataManager will ignore the file type.
+        The include_mimes can be overwritten by passing filenames directly.
+
+    """
+    def __init__(self, datapath: str = None, cache: bool = True, debug: bool = False, **kwargs) -> None:
+        """
+        You can pass in a Config as kwargs.
+        """
+        # check if the no config - or config without datapath - was passed
+        if datapath is None:
+            from ruins.core import Config
+            self.from_config(**Config(**kwargs))
+        else:
+            self.from_config(datapath=datapath, cache=cache, debug=debug, **kwargs)
+    
+    def from_config(self, datapath: str = None, cache: bool = True, debug: bool = False, **kwargs) -> None:
+        """
+        Initialize the DataManager from a :class:`Config <ruins.core.Config>` object.
+        """
+        # store the main settings
+        self._config = kwargs
+        self._datapath = datapath
+        self.cache = cache
+        self.debug = debug
+
+        # file settings
+        self._data_sources = {}
+
+        # infer data source
+        if self._datapath is not None:
+            self._infer_from_folder()
+    
+    @property
+    def datapath(self) -> str:
+        return self._datapath
+
+    @datapath.setter
+    def datapath(self, path: str) -> None:
+        if os.path.exists(path):
+            self._datapath = path
+            self._infer_from_folder()
+        else:
+            raise OSError(f"{path} does not exist.")
+    
+    @property
+    def datasources(self) -> List[DataSource]:
+        return list(self._data_sources.keys())
+
+    def _infer_from_folder(self) -> None:
+        """
+        Read all files from the datapath as specified on instantiation.
+        Calls :func:`add_source` on each file.
+        """
+        # get a list of all files
+        file_list = glob.glob(os.path.join(self.datapath, '*'))
+        file_list.extend(glob.glob(os.path.join(self.datapath, '**', '*')))
+
+
+        for fname in file_list:
+            self.add_source(path=fname, not_exists='warn' if self.debug else 'ignore')
+
+    def add_source(self, path: str, not_exists: str = 'raise') -> None:
+        """
+        Add a file as data source to the DataManager.
+        Only if the file has an allowed file extension, it will be managed.
+        Files of same name will be overwritten, this is also true if they had
+        different extensions.
+
+        """
+        # load the tracked
+        mimes = self._config.get('include_mimes', DEFAULT_MIMES)
+
+        # get the basename
+        try:
+            basename, mime = os.path.basename(path).split('.')
+        except ValueError:
+            if self.debug:
+                print(f"[Warning]: {path} has no extension.")
+            return 
+        
+        if mime in mimes.keys():
+            # get the class - overwirte by direct kwargs settings if needed
+            clsName = mimes[mime] if basename not in self._config else self._config[basename]
+            BaseClass = self.resolve_class_name(clsName)
+            
+            # add the source
+            args = self._config.get(basename, {})
+            args.update({'path': path, 'cache': self.cache})
+            self._data_sources[basename] = BaseClass(**args)
+        else:
+            if not_exists == 'raise':
+                raise OSError(f"{path} is not a configured data source")
+            elif not_exists == 'ignore':
+                pass
+            elif not_exists == 'warn':
+                print(f"{path} is found, but not a configured data source")
+
+    def resolve_class_name(self, cls_name: str) -> Type[DataSource]:
+        # checkout globals
+        cls = globals().get(cls_name, False)
+        
+        # do we have a class?
+        if not cls:
+            # TODO, there is maybe an extension module to search one day
+            raise RuntimeError(f"Can't find class {cls_name}.")
+        
+        return cls
+
+    def __len__(self):
+        """Return the number of managed data sources"""
+        return len(self._data_sources)
+
+    def __iter__(self):
+        """Iterate over all dataset names"""
+        for name in self._data_sources.keys():
+            yield name
+    
+    def __getitem__(self, key: str):
+        """Return the requested datasource"""
+        return self._data_sources[key]
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(datapath={self.datapath}, cache={self.cache})"
+    
+    def __str__(self):
+        return f"<DataManager of {len(self)} sources>"

--- a/ruins/core/data_manager.py
+++ b/ruins/core/data_manager.py
@@ -44,11 +44,6 @@ from collections.abc import Mapping
 from typing import Type, List
 
 
-DEFAULT_MIMES = {
-    'nc': 'HDF5Source',
-    'csv': 'CSVSource',
-}
-
 
 class DataSource(abc.ABC):
     """
@@ -209,8 +204,11 @@ class DataManager(Mapping):
         different extensions.
 
         """
-        # load the tracked
-        mimes = self._config.get('include_mimes', DEFAULT_MIMES)
+        # load the tracked source base class
+        mimes = self._config.get('default_sources', {})
+
+        # check if the config holds arguments for this source instance
+        args = self._config.get('sources_args', {}).get(os.path.basename(path), {})
 
         # get the basename
         try:
@@ -226,7 +224,7 @@ class DataManager(Mapping):
             BaseClass = self.resolve_class_name(clsName)
             
             # add the source
-            args = self._config.get(basename, {})
+#            args = self._config.get(basename, {})
             args.update({'path': path, 'cache': self.cache})
             self._data_sources[basename] = BaseClass(**args)
         else:

--- a/ruins/tests/test_config.py
+++ b/ruins/tests/test_config.py
@@ -16,8 +16,8 @@ def test_default_config():
     # initialize config without arguments
     conf = core.Config()
 
-    assert conf.datapath == datapath
-    assert conf.basepath == basepath
+    assert conf.datapath.lower() == datapath.lower()
+    assert conf.basepath.lower() == basepath.lower()
     assert conf.debug is False
 
 
@@ -28,8 +28,8 @@ def test_config_overwrites():
 
     conf = core.Config(datapath=temppath)
 
-    assert conf.basepath == basepath
-    assert conf.datapath == temppath
+    assert conf.basepath.lower() == basepath.lower()
+    assert conf.datapath.lower() == temppath.lower()
 
 
 def test_from_json():

--- a/ruins/tests/test_datamanager.py
+++ b/ruins/tests/test_datamanager.py
@@ -1,0 +1,31 @@
+import xarray as xr
+
+from ruins.core import DataManager
+from ruins.core.data_manager import HDF5Source
+
+
+def test_default_manager():
+    """Instantiate the default data manager"""
+    dm = DataManager()
+
+    assert dm.cache == True
+
+    # find some datasets weather dataset
+    assert 'cordex_coast' in dm.datasources
+    assert 'CMIP5grid' in dm.datasources
+
+
+def test_weather_dataset():
+    """Test the weather dataset"""
+    dm = DataManager()
+
+    # check weather dataset was loaded
+    assert 'weather' in dm.datasources
+
+    # check Source type
+    weather = dm['weather']
+    assert isinstance(weather, HDF5Source)
+
+    # load the data
+    data = weather.read()
+    assert isinstance(data, xr.Dataset)


### PR DESCRIPTION
This Pull request re-arranges the source file configurations. 

With the changes in place, the classes can just be instantiated and work by default, while being highly customizable. Now, every file extension has it's own base class, which can be configured by the basename, through the config. This removes hard coded constants in the source files in favor of instance attributes of the `Config` class, which can be overwritten at runtime.

It looks a bit oversized, but this should enable us to config the attributes, that only apply to specific files in the Config class (at a single palce) like this: 
https://github.com/hydrocode-de/RUINSapp/blob/d70eedfc8cf19b257aa9c8c5529fc621a01ea409/ruins/core/config.py#L42

closes #27