### PR TITLE
add archive downloader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN mkdir -p /src/data
 
 # copy the sources
 COPY ./ruins /src/ruins
-COPY ./data /src/data
 COPY ./requirements.txt /src/requirements.txt
 COPY ./setup.py /src/setup.py
 COPY ./README.md /src/README.md
@@ -20,6 +19,9 @@ COPY ./LICENSE /src/LICENSE
 # install
 RUN pip install --upgrade pip
 RUN cd /src && pip install -e .
+
+# download and install the data
+RUN python -c "from ruins.core import download_data_archive; download_data_archive()"
 
 # create the streamlit entrypoint
 WORKDIR /src/ruins/apps

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ climate-indices
 pillow
 sklearn
 fire
+requests

--- a/ruins/core/__init__.py
+++ b/ruins/core/__init__.py
@@ -1,3 +1,3 @@
 from .config import Config
 from .data_manager import DataManager
-from .build import build_config
+from .build import build_config, download_data_archive


### PR DESCRIPTION
This PR adds a core function to downlaod the data from a remote server. 
We need this at various steps: 

1. someone might install the pip packages, which does not include the data 
2. building the docker images for deployment would need git-lfs, which is a huge bottleneck

Now, we can change the Dockerfile to use the new utility. In perspective, I would move the data to a Zenodo repo on its own, making up a real data publication. @cojacoo what do you think? I think that kind of makes sense, then the app would download the data from zenodo (once on install on the server). New data versions if needed can be reflected in zenodo and if anyone downloads figures from the app we can make him cite the app, any related publications, but also the data.

@cojacoo, if you like the zenodo idea, just comment here and I will issue a new pull request after this one was merged.

@AlexDo1 can you check the new function on your machine locally?

```python
from ruins.core import download_data_archive

# this should throw an exception:
download_data_archive()

# this should remove existing data and download the 'new' one
download_data_archive(if_exists='prune')
```