### PR TITLE
Climate explorer - bug fixes and story mode draft

### DIFF
--- a/ruins/apps/climate.py
+++ b/ruins/apps/climate.py
@@ -8,20 +8,6 @@ from ruins.core import build_config, debug_view, Config, DataManager
 from ruins.plotting import monthlyx
 from ruins.components import topic_select, model_scale_select, data_select
 
-# TODO: Build this into DataManager
-def load_data(sel='Weather',regagg=None):
-    #Read data from netcdf files and return xarray
-    if sel == 'Weather':
-        data = xr.load_dataset('data/weather.nc')
-    elif sel == 'CORDEX':
-        data = xr.load_dataset('data/cordex_coast.nc')
-    else:
-        if regagg == 'North Sea Coast':
-            data = xr.load_dataset('data/cordex_coast.nc')
-            data.filter_by_attrs(RCP=sel)
-
-    return data
-
 
 # TODO refactor the plots into the plotting module
 def climate_explorer(dataManager: DataManager, config: Config):
@@ -88,6 +74,8 @@ def climate_explorer(dataManager: DataManager, config: Config):
 
     # TODO: build this into a Component
     if cliproj=='Regional':
+        st.warning('Sorry, we currently have issues with the Regional model data. Please come back later.')
+        st.stop()
         regaggs = ['North Sea Coast', 'Krummhörn',  'Niedersachsen', 'Inland']
         regagg = st.sidebar.selectbox('Spatial aggregation:', regaggs)
 

--- a/ruins/apps/climate.py
+++ b/ruins/apps/climate.py
@@ -37,13 +37,56 @@ def climate_explorer(dataManager: DataManager, config: Config):
     topic_expander = st.sidebar.expander('Topic selection', expanded=True)
     topic = topic_select.topic_select(config=config, topic_list=['Warming'], expander_container=topic_expander)
 
-    # select first reference
+    # ----------------------
+    # SELECT FIRST REFERENCE
     data_select.rcp_selector(dataManager, config, title='Select first reference', expander_container=option_container, elements='__all__', layout='columns', RCP_KEY='rcp_reference_1', allow_skip=False)
-    data_select.rcp_selector(dataManager, config, title='Select second reference', expander_container=option_container, elements='__all__', layout='row', RCP_KEY='rcp_reference_2', allow_skip=False)
     cref1 = config['rcp_reference_1']
+
+    if cref1=='weather':
+        data1 = dataManager['weather'].read()
+        data1 = data1.coast
+        drngx1 = (1980,2000)
+    else:
+        data1 = dataManager['cordex_coast'].read()
+        drngx1 = (2050, 2070)
+    
+    # filter for rcps
+    if cref1 == 'rcp26':
+        data1 = data1.filter_by_attrs(RCP='rcp26')
+    elif cref1 == 'rcp45':
+        data1 = data1.filter_by_attrs(RCP='rcp45')
+    elif cref1 == 'rcp85':
+        data1 = data1.filter_by_attrs(RCP='rcp85')
+
+    # create the date range silder
+    drng1 = [pd.to_datetime(data1.isel(time=0, vars=1).time.values).year, pd.to_datetime(data1.isel(time=-1, vars=1).time.values).year]
+    datarng1 = option_container.slider('Data range', drng1[0], drng1[1], drngx1, key='dr1')
+
+    # -----------------------
+    # SELECT SECOND REFERENCE
+    data_select.rcp_selector(dataManager, config, title='Select second reference', expander_container=option_container, elements='__all__', layout='row', RCP_KEY='rcp_reference_2', allow_skip=False)
     cref2 = config['rcp_reference_2']
 
-    # TODO REFACTOR FROM HERE
+    if cref2 == 'weather':
+        data2 = dataManager['weather'].read()
+        drngx2 = (1980, 2000)
+    else:
+        data2 = dataManager['cordex_coast'].read()
+        drngx2 = (2050, 2070)
+    
+    # filter for rcps
+    if cref2 == 'rcp26':
+        data2 = data2.filter_by_attrs(RCP='rcp26')
+    elif cref2 == 'rcp45':
+        data2 = data2.filter_by_attrs(RCP='rcp45')
+    elif cref2 == 'rcp85':
+        data2 = data2.filter_by_attrs(RCP='rcp85')
+
+    # create the date range silder
+    drng2 = [pd.to_datetime(data2.isel(time=0, vars=1).time.values).year, pd.to_datetime(data2.isel(time=-1, vars=1).time.values).year]
+    datarng2 = option_container.slider('Data range', drng2[0], drng2[1], drngx2, key='dr2')
+
+    # TODO: build this into a Component
     if cliproj=='Regional':
         regaggs = ['North Sea Coast', 'Krummhörn',  'Niedersachsen', 'Inland']
         regagg = st.sidebar.selectbox('Spatial aggregation:', regaggs)
@@ -54,53 +97,14 @@ def climate_explorer(dataManager: DataManager, config: Config):
         elif regagg=='Krummhörn':
             climate = xr.load_dataset('data/cordex_krummh.nc')
 
-#    st.subheader('Climate Model Comparison')
-#    crefs = ['Weather Data', 'all RCPs', 'RCP2.6', 'RCP4.5','RCP8.5']
-#    cref1 = st.sidebar.selectbox('Select first reference:', options=crefs)
-
-    if cref1=='weather':
-        data1 = load_data('Weather')
-        data1 = data1.coast
-        drngx1 = (1980,2000)
-    elif cref1 == 'allRCP':
-        data1 = load_data('CORDEX')
-        drngx1 = (2050, 2070)
-    elif cref1 == 'rcp26':
-        data1 = load_data('rcp26','North Sea Coast')
-        drngx1 = (2050, 2070)
-    elif cref1 == 'rcp45':
-        data1 = load_data('rcp45', 'North Sea Coast')
-        drngx1 = (2050, 2070)
-    elif cref1 == 'rcp85':
-        data1 = load_data('rcp85','North Sea Coast')
-        drngx1 = (2050, 2070)
-
-    drng1 = [pd.to_datetime(data1.isel(time=0, vars=1).time.values).year, pd.to_datetime(data1.isel(time=-1, vars=1).time.values).year]
-    datarng1 = st.sidebar.slider('Data range', drng1[0], drng1[1], drngx1, key='dr1')
-
-#    cref2 = st.sidebar.selectbox('Select second reference:', options=crefs)
-    if cref2 == 'weather':
-        data2 = load_data('Weather')
-        drngx2 = (1980, 2000)
-    elif cref2 == 'allRCP':
-        data2 = load_data('CORDEX')
-        drngx2 = (2050, 2070)
-    elif cref2 == 'rcp26':
-        data2 = load_data('rcp26','North Sea Coast')
-        drngx2 = (2050, 2070)
-    elif cref2 == 'rcp45':
-        data2 = load_data('rcp45', 'North Sea Coast')
-        drngx2 = (2050, 2070)
-    elif cref2 == 'rcp85':
-        data2 = load_data('rcp85','North Sea Coast')
-        drngx2 = (2050, 2070)
-
-    drng2 = [pd.to_datetime(data2.isel(time=0, vars=1).time.values).year, pd.to_datetime(data2.isel(time=-1, vars=1).time.values).year]
-    datarng2 = st.sidebar.slider('Data range', drng2[0], drng2[1], drngx2, key='dr2')
-
-    if w_topic == 'Warming':
+    # ------------------
+    # Main Area
+    plot_opts, plot_area = st.columns((2, 8))
+    
+    # TODO: Use the actual selected topic here
+    if config['current_topic'] == 'Warming':
         navi_vars = ['Maximum Air Temperature', 'Mean Air Temperature', 'Minimum Air Temperature']
-        navi_var = st.sidebar.radio("Select variable:", options=navi_vars)
+        navi_var = plot_opts.radio("Select variable:", options=navi_vars)
         if navi_var[:4] == 'Mini':
             vari = 'Tmin'
             afu = np.min
@@ -114,13 +118,15 @@ def climate_explorer(dataManager: DataManager, config: Config):
             afu = np.mean
             ag = 'mean'
 
+        # apply aggreagtion
         dyp = data1.sel(vars=vari).to_dataframe().resample('1M').apply(afu)
         dyp = dyp.loc[(dyp.index.year>=datarng1[0]) & (dyp.index.year<datarng1[1]),dyp.columns[dyp.columns!='vars']]
         dyp2 = data2.sel(vars=vari).to_dataframe().resample('1M').apply(afu)
         dyp2 = dyp2.loc[(dyp2.index.year >= datarng2[0]) & (dyp2.index.year < datarng2[1]),dyp2.columns[dyp2.columns!='vars']]
 
-        monthlyx(dyp, dyp2, 'Temperature (°C)', 'Monthly '+ag+' in Year ('+cref1+')', 'Monthly '+ag+' in Year ('+cref2+')')
-        st.pyplot()
+        # create the plot
+        fig = monthlyx(dyp, dyp2, 'Temperature (°C)', 'Monthly '+ag+' in Year ('+cref1+')', 'Monthly '+ag+' in Year ('+cref2+')')
+        st.pyplot(fig=fig)
 
 
 def main_app(**kwargs):

--- a/ruins/apps/climate.py
+++ b/ruins/apps/climate.py
@@ -6,7 +6,7 @@ import pandas as pd # TODO this should be covered by the DataManager
 
 from ruins.core import build_config, debug_view, Config, DataManager
 from ruins.plotting import monthlyx
-from ruins.components import topic_select, model_scale_select
+from ruins.components import topic_select, model_scale_select, data_select
 
 # TODO: Build this into DataManager
 def load_data(sel='Weather',regagg=None):
@@ -37,6 +37,12 @@ def climate_explorer(dataManager: DataManager, config: Config):
     topic_expander = st.sidebar.expander('Topic selection', expanded=True)
     topic = topic_select.topic_select(config=config, topic_list=['Warming'], expander_container=topic_expander)
 
+    # select first reference
+    data_select.rcp_selector(dataManager, config, title='Select first reference', expander_container=option_container, elements='__all__', layout='columns', RCP_KEY='rcp_reference_1', allow_skip=False)
+    data_select.rcp_selector(dataManager, config, title='Select second reference', expander_container=option_container, elements='__all__', layout='row', RCP_KEY='rcp_reference_2', allow_skip=False)
+    cref1 = config['rcp_reference_1']
+    cref2 = config['rcp_reference_2']
+
     # TODO REFACTOR FROM HERE
     if cliproj=='Regional':
         regaggs = ['North Sea Coast', 'Krummhörn',  'Niedersachsen', 'Inland']
@@ -48,44 +54,44 @@ def climate_explorer(dataManager: DataManager, config: Config):
         elif regagg=='Krummhörn':
             climate = xr.load_dataset('data/cordex_krummh.nc')
 
-    st.subheader('Climate Model Comparison')
-    crefs = ['Weather Data', 'all RCPs', 'RCP2.6', 'RCP4.5','RCP8.5']
-    cref1 = st.sidebar.selectbox('Select first reference:', options=crefs)
+#    st.subheader('Climate Model Comparison')
+#    crefs = ['Weather Data', 'all RCPs', 'RCP2.6', 'RCP4.5','RCP8.5']
+#    cref1 = st.sidebar.selectbox('Select first reference:', options=crefs)
 
-    if cref1=='Weather Data':
+    if cref1=='weather':
         data1 = load_data('Weather')
         data1 = data1.coast
         drngx1 = (1980,2000)
-    elif cref1 == 'all RCPs':
+    elif cref1 == 'allRCP':
         data1 = load_data('CORDEX')
         drngx1 = (2050, 2070)
-    elif cref1 == 'RCP2.6':
+    elif cref1 == 'rcp26':
         data1 = load_data('rcp26','North Sea Coast')
         drngx1 = (2050, 2070)
-    elif cref1 == 'RCP4.5':
+    elif cref1 == 'rcp45':
         data1 = load_data('rcp45', 'North Sea Coast')
         drngx1 = (2050, 2070)
-    elif cref1 == 'RCP8.5':
+    elif cref1 == 'rcp85':
         data1 = load_data('rcp85','North Sea Coast')
         drngx1 = (2050, 2070)
 
     drng1 = [pd.to_datetime(data1.isel(time=0, vars=1).time.values).year, pd.to_datetime(data1.isel(time=-1, vars=1).time.values).year]
     datarng1 = st.sidebar.slider('Data range', drng1[0], drng1[1], drngx1, key='dr1')
 
-    cref2 = st.sidebar.selectbox('Select second reference:', options=crefs)
-    if cref2 == 'Weather Data':
+#    cref2 = st.sidebar.selectbox('Select second reference:', options=crefs)
+    if cref2 == 'weather':
         data2 = load_data('Weather')
         drngx2 = (1980, 2000)
-    elif cref2 == 'all RCPs':
+    elif cref2 == 'allRCP':
         data2 = load_data('CORDEX')
         drngx2 = (2050, 2070)
-    elif cref2 == 'RCP2.6':
+    elif cref2 == 'rcp26':
         data2 = load_data('rcp26','North Sea Coast')
         drngx2 = (2050, 2070)
-    elif cref2 == 'RCP4.5':
+    elif cref2 == 'rcp45':
         data2 = load_data('rcp45', 'North Sea Coast')
         drngx2 = (2050, 2070)
-    elif cref2 == 'RCP8.5':
+    elif cref2 == 'rcp85':
         data2 = load_data('rcp85','North Sea Coast')
         drngx2 = (2050, 2070)
 
@@ -121,7 +127,7 @@ def main_app(**kwargs):
     """@TODO: describe kwargs here"""
     # build the config and dataManager from kwargs
     url_params = st.experimental_get_query_params()
-    config, dataManager = build_config(url_params, **kwargs)
+    config, dataManager = build_config(url_params=url_params, **kwargs)
 
     # set page properties and debug view
     st.set_page_config(page_title='Climate Explorer', layout=config.layout)

--- a/ruins/components/data_select.py
+++ b/ruins/components/data_select.py
@@ -5,6 +5,7 @@ Data Select
 Alex will das dokumentieren....
 
 """
+from typing import List, Union
 import streamlit as st
 
 from ruins.core import DataManager, Config
@@ -28,6 +29,39 @@ _TRANSLATE_DE = dict(
     rcp_description="""RCPs sind mögliche Szenarios der Treibhausgaskonentrationen in der Atmosphäre bis zum Jahr 2100. RCP2.6 orientiert sich am Pariser Klimaabkommen von 2015, demnach kaum mehr Treibhasugase ausgestoßen werden. RCP8.5 beschreibt einen eher risikofreudigen Umgang, bei dem Konzentrationen ähnlich einem Worst-Case Szenario weiter ansteigen. RCP4.5 is ein moderates Modell, das eher an der Realität orientiert ist.. Es ist wichtig zu beachten, dass die schwierige Differenzierbarkeit zwischen RCP Szenarios seit langem diskutiert wird. Ein Ausgang ist die Definition von Shared Socioeconomic Pathways (SSPs), für die heute jedoch nur wenige Modell-Runs verfügbar sind. Für weitere Informationen, siehe [Climatescenario Primer](https://climatescenarios.org/primer/), [CarbonBrief](https://www.carbonbrief.org/explainer-how-shared-socioeconomic-pathways-explore-future-climate-change) oder dieser [Nature Comment](https://www.nature.com/articles/d41586-020-00177-3) kontaktieren.""",
     rcp_inftext = "### Klimaprojektionen hinzufügen?\nSie können eines der Szenarios unten auswählen, oder 'Keine' auswählen, um diesen Schritt zu überspringen. Jedes Szenario hat ein verlinktes Video von https://sos.noaa.gov/ zur Darstellung der Änderungen durch das Szenario."
 )
+
+_VIDEO_SOURCES = {
+    'default': dict(
+        title='### {rcp}',
+        description='Video Source: [NOAA Science On a Sphere](https://sos.noaa.gov/catalog/datasets/climate-model-temperature-change-rcp-{rcp}-2006-2100/)',
+        video_url='https://sos.noaa.gov/videos/rcp_ga_{rcp}_400.mp4'
+    ),
+    'rcp26': dict(
+        title='### RCP 2.6',
+        description='Video Source: [NOAA Science On a Sphere](https://sos.noaa.gov/catalog/datasets/climate-model-temperature-change-rcp-26-2006-2100/)',
+        video_url='https://sos.noaa.gov/videos/rcp_ga_26_400.mp4'
+    ),
+    'rcp45': dict(
+        title='### RCP 4.5',
+        description='Video Source: [NOAA Science On a Sphere](https://sos.noaa.gov/catalog/datasets/climate-model-temperature-change-rcp-45-2006-2100/)',
+        video_url='https://sos.noaa.gov/videos/rcp_ga_45_400.mp4'
+    ),
+    'rcp85': dict(
+        title='### RCP 8.5',
+        description='Video Source: [NOAA Science On a Sphere](https://sos.noaa.gov/catalog/datasets/climate-model-temperature-change-rcp-85-2006-2100/)',
+        video_url='https://sos.noaa.gov/videos/rcp_ga_85_400.mp4'
+    ),
+    'allRCP': dict(
+        title='all RCPs',
+        description='All RCPs try to project CO2 concentrations, like shown in the video. Source: [NOAA Science On a Sphere](https://sos.noaa.gov/catalog/datasets/carbon-dioxide-concentration-geos-5-model/)',
+        video_url='https://sos.noaa.gov/videos/geos_5_carbon_400_audio.mp4'
+    ),
+    'weather': dict(
+        title='Weather Data',
+        description='Compare with weather observations. The video shows the current global precipitation. [SOURCE](https://sos.noaa.gov/catalog/datasets/clouds-with-precipitation-real-time/)',
+        video_url='https://sos.noaa.gov/videos/clouds_precip_400.mp4'
+    ),
+}
 
 
 def _map_wrapper(dataManager: DataManager, config: Config, expander_container = st.sidebar, add_caption: bool = True, **kwargs):
@@ -118,60 +152,95 @@ def temporal_agg_selector(dataManager: DataManager, config: Config, expander_con
     st.experimental_rerun()
 
 
-def rcp_selector(dataManager: DataManager, config: Config, expander_container = st.sidebar, **kwargs):
+def rcp_selector(dataManager: DataManager, config: Config, expander_container = st.sidebar, elements: Union[str, List[str]] = '__rpc__',  **kwargs):
     """
     Decide whether to include or exclude climate projects. 
     If climate projections should be included, the user can select one of the projections.
     """
+    # RCP key to use - needed for multiple selects
+    RCP_KEY = kwargs.get('RCP_KEY', 'current_rcp')
+
     # get the container
     container = st if 'container' not in kwargs else kwargs['container']
     t = kwargs.get('translator', config.translator(en=_TRANSLATE_EN, de=_TRANSLATE_DE))
 
-    # get all available climate projections
-    projections = sorted(list(set([_.split('.')[-1] for _ in dataManager['cordex_coast'].read().keys()])))
+    # check what to show as projections
+    if elements == '__rpc__':
+        # get all available climate projections
+        projections = sorted(list(set([_.split('.')[-1] for _ in dataManager['cordex_coast'].read().keys()])))
+    elif elements == '__all__':
+        # get all available climate projections
+        projections = sorted(list(set([_.split('.')[-1] for _ in dataManager['cordex_coast'].read().keys()])))
+        projections = ['weather', 'allRCP'] + projections
+
+    elif isinstance(elements, str):
+        projections = [elements]
+    else:
+        projections = elements
 
     # check mode
-    if config.has_key('include_climate'):
+    if config.has_key('include_climate') and kwargs.get('allow_skip', True):
         cap = 'Include climate projections' if config.lang == 'en' else 'Klimaprojektionen hinzufügen?'
         expander_container.checkbox(cap, key='include_climate')
 
-        # add the selectbox
-        if config['include_climate']:
-            cap = 'Select RCP:' if config.lang == 'en' else 'RCP auswählen:'
-            expander_container.selectbox(cap, projections, key='current_rcp', format_func=lambda x: x.upper())
+    # add the selectbox
+    if config.has_key(RCP_KEY):
+        cap = 'Select RCP:' if config.lang == 'en' else 'RCP auswählen:'
+        expander_container.selectbox(cap, projections, key=RCP_KEY, format_func=lambda x: x.upper())
         return
     
     # main content
-    container.title(t('rcp_title'))
+    layout = kwargs.get('layout', 'columns')
+    
+    # title
+    container.title(kwargs.get('title', t('rcp_title')))
 
     container.markdown(t('rcp_description'), unsafe_allow_html=True)
 
-    container.info("RPCs are cool, but make stuff a bit slower")
+#    container.info("RPCs are cool, but make stuff a bit slower")
     container.markdown(t('rcp_infotext'))
-    no = container.button('Ohne Klimaprojektionen fortfahren' if config.lang == 'de' else 'Continue without climate projections')
 
-    # handle the no
-    if no:
-        st.session_state.include_climate = False
-        st.experimental_rerun()
+    # check if the user can skip this step
+    if kwargs.get('allow_skip', True):
+        no = container.button('Ohne Klimaprojektionen fortfahren' if config.lang == 'de' else 'Continue without climate projections')
+
+        # handle the no
+        if no:
+            st.session_state.include_climate = False
+            st.experimental_rerun()
     
     # build the columns
-    cols = container.columns(len(projections))
-    url = config['rcp_video_url']
+    if layout == 'columns':
+        cols = container.columns(len(projections))
+    else:
+        cols = [container.columns((1,2,2)) for _ in range(len(projections))]
+    
+    # container for click buttons
     use_rcp = []
+    
+    # go for it
     for col, rcp in zip(cols, projections):
+        # get the layout and the data
+        c = (col, col, col) if layout == 'columns' else col
+        _dat = _VIDEO_SOURCES.get(rcp, _VIDEO_SOURCES['default'])
+        
+        print(rcp)
         # video
-        col.video(url.format(rcp=rcp[-2:]))
-        col.markdown(f"### {rcp.upper()}")
-        col.markdown(f'Video Source: [NOAA Science On a Sphere](https://sos.noaa.gov/catalog/datasets/climate-model-temperature-change-rcp-{rcp[-2:]}-2006-2100/)')
-        use = col.button(f'Use {rcp.upper()}')
+        c[0].video(_dat['video_url'].format(rcp=rcp[-2:]))
+        
+        # description
+        c[1].markdown(_dat['title'].format(rcp=rcp.upper()))
+        c[1].markdown(_dat['description'].format(rcp=rcp))
+        
+        # button
+        use = c[2].button(f'Use {rcp.upper()}')
         use_rcp.append((use, rcp))
     
     # check if any button was used:
     for use, rcp in use_rcp:
         if use:
             st.session_state.include_climate = True
-            st.session_state.current_rcp = rcp
+            st.session_state[RCP_KEY] = rcp
             st.experimental_rerun()
     
     # if we didn't restart, stop the application

--- a/ruins/components/model_scale_select.py
+++ b/ruins/components/model_scale_select.py
@@ -1,0 +1,128 @@
+"""
+Model scale selector
+"""
+import streamlit as st
+
+from ruins.core import DataManager, Config
+
+
+_TRANSLATE_EN = dict(
+    title='Climate models have scale',
+    description="""
+There are many scientists working in different groups to build and enhance computer models of the climate physics.
+These models operate at different scales in space and time. In our case, we refer to i) **global climate model** 
+projections with a spatial resolution of approx. 120 km of one pixel at the surface and to ii) 
+**regional climate model** projections with a spatial resolution of approx. 11 km.
+As the name suggests, global climate models (or GCMs) cover the whole globe.
+Their speciality is to simulate the overall physics of the atmosphere and land surface interactions.
+The regional climate models (or RCMs) build on top of GCMs and build physical and/or statistical relationships
+between GCM-outputs and locally observed weather. They seek to compensate the very coarse approximations of GCMs at
+the price of more data being extrapolated into the future.
+
+For more detailed reading, please continue here:
+[CarbonBrief - How do climate models work?](https://www.carbonbrief.org/qa-how-do-climate-models-work)
+    """,
+    options={
+        'Global': 'Global model',
+        'Regional': 'Regional model'
+    }
+)
+
+_TRANSATE_DE = dict(
+    title='Skalierung von Klimamodellen',
+    description="""
+Es gibt unzählige Wissenschaftler_innen und Institutionen, die an einer Verbesserung der Computermodelle und dem
+zugrundeliegenden physikalischen Verständnis arbeiten. Diese Modelle operieren auf verschiedenen *räumlichen* und 
+*zeitlichen* Skalen. In dieser App haben **Globale Klimamodelle** eine räumlcihe Auflösung von ca. 120km pro Pixel an der
+Erdoberfläche. **Regionale Klimamodelle** haben hingegen eine räumliche Auflösung von ca. 11km.
+Dafür bedecken globale Modelle, wie der Name schon sagt, die ganze Welt. Sie sind besonders gut geeignet um globale Strömungen
+und Interaktionen zwischen der Atmophäre und der Landoberfläche zu simulieren.
+Die Regionalen modelle (RCMs) bauen dann weiter auf den (GCMs) auf, indem Sie globale Modelle entweder über statistische
+oder physikalische Zusammenhänge mit lokal erhobenen Messdaten verknüpfen. Damit soll die grobe Auflösung von GCMs
+wettgemacht werden.
+
+Für mehr Informationen, lese hier weiter:
+[CarbonBrief - Wie funktionieren Klimamodelle?](https://www.carbonbrief.org/qa-how-do-climate-models-work)
+    """,
+    options={
+        'Global': 'Globales Modell',
+        'Regional': 'Regionales Modell'
+    }
+)
+
+
+def model_scale_selector(dataManager: DataManager, config: Config, expander_container=st.sidebar, **kwargs):
+    """
+    """
+    # get the container
+    container = st if 'container' not in kwargs else kwargs['container']
+
+    # get a translator
+    t = config.translator(en=_TRANSLATE_EN, de=_TRANSATE_DE)
+
+    # get the translated options
+    OPTIONS = t('options')
+    # check if main page was already shown
+    if config.has_key('climate_scale'):
+        expander_container.radio(
+            'Climate model' if config.lang == 'en' else 'Klimamodell',
+            options=list(OPTIONS.keys()),
+            format_func=lambda k: OPTIONS.get(k),
+            key='climate_scale'
+        )
+        return
+
+    # add the title
+    container.title(t('title'))
+
+    # add the description
+    container.markdown(t('description'), unsafe_allow_html=True)
+
+    # add the columns
+    right, left = container.columns(2)
+
+    right.info('THIS IS A THUMBNAIL')
+    use_global = right.button('USE GLOBAL MODELS' if config.lang == 'en' else 'GLOBALES MODELL')
+
+    left.info('THIS IS A THUMBNAIL')
+    use_regional = left.button('USE REGIONAL MODELS' if config.lang == 'en' else 'REGIONALES MODELL')
+
+    if use_global:
+        st.session_state.climate_scale = 'Global'
+        st.experimental_rerun()
+    elif use_regional:
+        st.session_state.climate_scale = 'Regional'
+        st.experimental_rerun()
+    else:
+        st.stop()
+
+
+def model_scale_select(dataManager: DataManager, config: Config, expander_container=st.sidebar, **kwargs):
+    """
+    """
+    # set default story mode 
+    story_mode = config.get('story_mode', True)
+    if 'story_mode' in kwargs:
+        story_mode = kwargs['story_mode']
+
+    # pre-select 
+    if config.has_key('climate_scale') or not story_mode:
+        st.session_state.climate_scale = config.get('climate_scale', 'Global')
+    
+    # call the seletor
+    model_scale_selector(dataManager, config, expander_container=expander_container)
+
+
+def debug_main(**kwargs):
+    from ruins.core import build_config
+    params = st.experimental_get_query_params()
+    config, dataManager = build_config(url_params=params, **kwargs)
+
+    model_scale_select(dataManager, config)
+
+    st.json(st.session_state)
+
+
+if __name__ == '__main__':
+    import fire
+    fire.Fire(debug_main)

--- a/ruins/core/config.py
+++ b/ruins/core/config.py
@@ -62,10 +62,9 @@ class Config(Mapping):
 
         # app content
         self.topic_list = ['Warming', 'Weather Indices']#, 'Drought/Flood', 'Agriculture', 'Extreme Events', 'Wind Energy']
-        self.rcp_video_url = 'https://sos.noaa.gov/videos/rcp_ga_{rcp}_400.mp4'
 
         # store the keys
-        self._keys = ['debug', 'lang', 'basepath', 'datapath', 'hot_load', 'default_sources', 'sources_args', 'layout', 'topic_list', 'rcp_video_url']
+        self._keys = ['debug', 'lang', 'basepath', 'datapath', 'hot_load', 'default_sources', 'sources_args', 'layout', 'topic_list']
 
         # check if a path was provided
         conf_args = self.from_json(path) if path else {}

--- a/ruins/plotting/weather_data.py
+++ b/ruins/plotting/weather_data.py
@@ -74,7 +74,7 @@ def yrplot_hm(sr, ref=[1980, 2000], ag='sum', qa=0.95, cbar_title='Temperature a
     return fig
 
 
-def monthlyx(dy, dyx=1, ylab='T (°C)', clab1='Monthly Mean in Year', clab2='Monthly Max in Year', pls='cividis_r'):
+def monthlyx(dy, dyx=1, ylab='T (°C)', clab1='Monthly Mean in Year', clab2='Monthly Max in Year', pls='cividis_r') -> plt.Figure:
     cmap = plt.cm.get_cmap(pls)
     colors = cmap(np.linspace(0, 1, len(dy.index.year.unique())+1))
     colorsx = cmap(np.arange(cmap.N))
@@ -114,5 +114,7 @@ def monthlyx(dy, dyx=1, ylab='T (°C)', clab1='Monthly Mean in Year', clab2='Mon
     plt.xticks([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
            ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'])
     plt.ylabel(ylab)
-    return
+
+    fig = plt.gcf()
+    return fig
 


### PR DESCRIPTION
This PR rebuilt most of climate exporer's internal:

* Uses the `DataManager` and `Config` for internal state management
* Reuses `topic_selector`
* Rebuilt the `rcp_selector` in major parts, to use it here.

The RCP selector can now show more options than just the RCPs found in the netCDF file, to be used here **and** in the weather explorer. Additionally, the selector can layout in columns or rows. The climate explorer makes use of both, but we should of course make a decision for either column (first reference station) or row (second reference station) for consistency. Decision is up to you @cojacoo.

The plot warning were also fixed but the plot layout was screwed up. Thus, after this PR is finished, @AlexDo1 can fix the layout again and @mmaelicke  will re-implement this plot using plotly, as the user has to be able to hover this plot.