### PR TITLE
Distribution plot moved to plotting library

### DIFF
--- a/ruins/apps/uncertainty.py
+++ b/ruins/apps/uncertainty.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy.stats import norm
 
 from ruins.core import Config, build_config, debug_view
+from ruins.plotting import distribution_plot
 
 _TRANSLATE_EN = dict(
     title='Uncertainty & Risk',
@@ -139,7 +140,6 @@ def _helper_plot(ev1: List[Tuple[float, float]], ev2: Tuple[float, float] = None
     return fig
 
 
-
 def concept_graph(config: Config, expander_container=st.sidebar, **kwargs) -> go.Figure:
     """
     # TODO: document this
@@ -172,7 +172,7 @@ def concept_graph(config: Config, expander_container=st.sidebar, **kwargs) -> go
             st.session_state.concept_event_1 = ev1
             st.experimental_rerun()
         else:
-            fig = _helper_plot(ev1)
+            fig = distribution_plot({'outcomes': ev1, 'coloscale': 'Greens'})
             return fig
     else:
         ev1 = config['concept_event_1']
@@ -193,7 +193,7 @@ def concept_graph(config: Config, expander_container=st.sidebar, **kwargs) -> go
     e2_mu = c.slider('Expected value of alternative event', min_value=1., max_value=10., value=5.5)
     e2_st = r.slider('Certainty of alternative event', min_value=0.1, max_value=3.0, value=0.2)
 
-    fig = _helper_plot(ev1_new, (e2_mu, e2_st))
+    fig = distribution_plot({'outcomes': ev1_new, 'name': 'Original Event', 'colorscale': 'Greens'}, {'outcomes': [(e2_mu, e2_st)], 'name': 'Alternative Event', 'colorscale': 'Oranges'})
     return fig
 
 

--- a/ruins/plotting/__init__.py
+++ b/ruins/plotting/__init__.py
@@ -3,3 +3,4 @@ from .kde import kde
 from .weather_data import monthlyx
 from .stripes_heatmap import yrplot_hm
 from .climate_parcoords import climate_projection_parcoords
+from .dists import distribution_plot

--- a/ruins/plotting/dists.py
+++ b/ruins/plotting/dists.py
@@ -1,0 +1,89 @@
+"""
+Distribution plots as used by the uncertainty application.
+"""
+from typing import List
+from itertools import cycle
+
+import numpy as np
+from scipy import stats
+import plotly.graph_objects as go
+from plotly.express.colors import unlabel_rgb, label_rgb, n_colors, sequential
+
+
+def distribution_plot(*events: List[dict], fig: go.Figure = None, **kwargs) -> go.Figure:
+    """Concept plot for PDFs of different events.
+    This plot illustrates the interdependece of Kngihtian uncertainty
+    and risk for a set of events. At least one event has to be passed.
+    
+    Parameters
+    ----------
+    events : List
+        Each event is represented by a dict, that has to contain the following keys:
+        outcomes: List[Tuple[float, float]]
+            The mu and std of each outcome for this event
+        Additionally, the following keys are optional:
+        dist : str
+            The distribution of the event. Default is 'norm'.
+        coloscale : str
+            The colorscale used to color the events. Default is a 
+            cycle through ['Greens', 'Reds', 'Blues']
+        name : str
+            Name for this event
+    
+    Returns
+    -------
+    fig : go.Figure
+        Result plot
+    """
+    # create a figure
+    if fig is None:
+        fig = go.Figure()
+
+    # get the x-axis
+    x = np.linspace(0, 10, 200)
+
+    # get the first event
+    if len(events) == 0:
+        raise ValueError('At least one event has specified')
+
+    # default colorscale names
+    COLORS = cycle(['Greens', 'Reds', 'Blues', 'Oranges', 'Greys'])
+
+    for event in events:
+        # get the distribution
+        dist = getattr(stats, event.get('dist', 'norm'))
+
+        # get the coloscale
+        cscale = getattr(sequential, event.get('colorscale', next(COLORS)))
+        cmap = n_colors(unlabel_rgb(cscale[-1]), unlabel_rgb(cscale[0]), len(event['outcomes']) + 2)
+
+        for i, outcome in enumerate(event['outcomes']):
+            mu, std = outcome
+            y = dist.pdf(x, loc=mu, scale=std)
+            y_sum = y.sum()
+            y /= y_sum
+
+            # add the traces
+            fig.add_trace(
+                go.Scatter(x=x, y=y * 100, 
+                mode='lines', 
+                line=dict(color=label_rgb(cmap[i])), 
+                name=event.get('name', f'Outcome #{i + 1}'), 
+                fill='tozerox'
+                )
+            )
+            fig.add_trace(
+                go.Scatter(x=[mu, mu], y=[0, dist.pdf(mu, loc=mu, scale=std) / y_sum * 100], 
+                mode='lines',
+                line=dict(color=label_rgb(cmap[i]), width=3, dash='dash'),
+                name=f"Mean {event.get('name', f'Outcome #{i + 1}')}",
+                )
+            )
+    # adjust figure
+    fig.update_layout(
+        template='plotly_white',
+        legend=dict(orientation='h')
+    )
+
+    # return
+    return fig


### PR DESCRIPTION
The new `plotting.distribution_plot` can now handle an arbitrary amount of (Knightian uncertain) events, each with an arbitrary amount of risky outcomes. The uncertainty app, however, does only compare an 'original event' with two outcomes to an 'alternative event' with only one outcome.
PDFs and locations are plotted for each outcome and event.