### PR TITLE
Fix kde warning

### DIFF
--- a/ruins/components/data_select.py
+++ b/ruins/components/data_select.py
@@ -224,7 +224,6 @@ def rcp_selector(dataManager: DataManager, config: Config, expander_container = 
         c = (col, col, col) if layout == 'columns' else col
         _dat = _VIDEO_SOURCES.get(rcp, _VIDEO_SOURCES['default'])
         
-        print(rcp)
         # video
         c[0].video(_dat['video_url'].format(rcp=rcp[-2:]))
         

--- a/ruins/plotting/kde.py
+++ b/ruins/plotting/kde.py
@@ -13,7 +13,7 @@ def kde(data, cmdata='none', split_ts=1, cplot=True, eq_period=True):
 
     # instantiate and fit the KDE model
     kde = KernelDensity(bandwidth=1.0, kernel='gaussian')
-    kde.fit(data[:, None])
+    kde.fit(data.to_numpy()[:, None])
 
     # score_samples returns the log of the probability density
     logprob = kde.score_samples(x_d[:, None])
@@ -30,7 +30,7 @@ def kde(data, cmdata='none', split_ts=1, cplot=True, eq_period=True):
         x_d2 = np.linspace(np.min(cmdata) * 0.9, np.max(cmdata) * 1.1, len(cmdata))
         # instantiate and fit second KDE model
         kde2 = KernelDensity(bandwidth=1.0, kernel='gaussian')
-        kde2.fit(cmdata[:, None])
+        kde2.fit(cmdata.to_numpy()[:, None])
 
         # score_samples returns the log of the probability density
         logprob2 = kde2.score_samples(x_d2[:, None])
@@ -56,7 +56,7 @@ def kde(data, cmdata='none', split_ts=1, cplot=True, eq_period=True):
             try:
                 # instantiate and fit the KDE model
                 kde = KernelDensity(bandwidth=1.0, kernel='gaussian')
-                kde.fit(datax[:, None])
+                kde.fit(datax.to_numpy()[:, None])
 
                 # score_samples returns the log of the probability density
                 logprob = kde.score_samples(x_d[:, None])
@@ -77,7 +77,7 @@ def kde(data, cmdata='none', split_ts=1, cplot=True, eq_period=True):
             try:
                 # instantiate and fit the KDE model
                 kde = KernelDensity(bandwidth=1.0, kernel='gaussian')
-                kde.fit(datax[:, None])
+                kde.fit(datax.to_numpy()[:, None])
 
                 # score_samples returns the log of the probability density
                 logprob = kde.score_samples(x_d[:, None])


### PR DESCRIPTION
This PR fixes the Future Warning in the `kde()` function:
```
/src/ruins/plotting/kde.py:16: FutureWarning:
Support for multi-dimensional indexing (e.g. `obj[:, None]`) is deprecated and will be removed in a future version.  Convert to a numpy array before indexing instead.
```

I also already checked that the results of the KDE fit remain unchanged.

Closes #49 