### PR TITLE
Nc instead csv

### DIFF
--- a/ruins/apps/extremes.py
+++ b/ruins/apps/extremes.py
@@ -94,7 +94,7 @@ def user_input_defaults():
 
     canal_area = 4 # user input: st.radio(
         #"Share of water area on catchment [%].",
-        #(3, 4))
+        #(4, 6))
     
     ## pump before event
     advance_pump = 0. # user input: st.radio(
@@ -224,7 +224,7 @@ def flood_model(dataManager: DataManager, config:Config, **kwargs):
         )
         Canal_area = st.radio(
             "Share of water area on catchment [%].",
-            (3, 4)
+            (4, 6)
         )
 
     # Model runs:

--- a/ruins/apps/extremes.py
+++ b/ruins/apps/extremes.py
@@ -164,7 +164,7 @@ def create_model_runs_list(all_kge_canal_par_df, kge, canal_flow_scale, canal_ar
          x_df['h_min'], 
          x_df['flow_rec'], 
          pump_cost) = drain_cap.storage_model(x_df,
-                                              z, 
+                                              canal_par = z, 
                                               storage = 0, 
                                               h_store = -1350, # geändert von Jonas
                                               canal_area = canal_area, 

--- a/ruins/apps/extremes.py
+++ b/ruins/apps/extremes.py
@@ -173,8 +173,8 @@ def create_model_runs_list(all_kge_canal_par_df, kge, canal_flow_scale, canal_ar
                                               v_store = 0, 
                                               h_store_target = -1350, # geändert von Jonas
                                               canal_area = canal_area, 
-                                              advance_pump = advance_pump, 
-                                              maxdh = maxdh,
+                                              h_forecast_pump = advance_pump, 
+                                              h_grad_pump_max = maxdh,
                                               pump_par = pumpcap_fit)
         model_runs.append((x_df['h_store'], pump_cost))
         #pump_capacity_model_runs.append(pump_cost)

--- a/ruins/apps/extremes.py
+++ b/ruins/apps/extremes.py
@@ -99,7 +99,7 @@ def user_input_defaults():
     ## pump before event
     advance_pump = 0. # user input: st.radio(
         #"Forecast Pumping",
-        #(0, 4)
+        #(0, 50)
 
     ## visualisation of used pump capacity
     # pump_vis = st.radio("Pump capacity visualisation", ["absolute", "cumulative"])
@@ -225,8 +225,8 @@ def flood_model(dataManager: DataManager, config:Config, **kwargs):
     # pump before event
     #    advance_pump = st.number_input("Additional spare volume in canals", min_value=-5., max_value=8., value= 0., step=0.1)
         advance_pump = st.radio(
-            "Forecast Pumping",
-            (0, 4)
+            "Lower water level by x mm NHN before event.",
+            (0, 50)
         )
         Canal_area = st.radio(
             "Share of water area on catchment [%].",

--- a/ruins/apps/extremes.py
+++ b/ruins/apps/extremes.py
@@ -228,7 +228,7 @@ def flood_model(dataManager: DataManager, config:Config, **kwargs):
             "Lower water level by x mm NHN before event.",
             (0, 50)
         )
-        Canal_area = st.radio(
+        canal_area = st.radio(
             "Share of water area on catchment [%].",
             (4, 6)
         )

--- a/ruins/apps/extremes.py
+++ b/ruins/apps/extremes.py
@@ -154,6 +154,11 @@ def create_model_runs_list(all_kge_canal_par_df, kge, canal_flow_scale, canal_ar
     kge_canal_par_df = all_kge_canal_par_df.loc[all_kge_canal_par_df.KGE == kge]
     canal_par_array = kge_canal_par_df[['parexponent', 'parfactor']].to_numpy()
     
+            ### Define parameters of the default pumping function / pump chart
+    x = np.array([7.,6.,5.,4.,3.5,3.,2,1,0,5.,4.,3.5,3.,2]) * 1000 # water gradient [mm] (by factor 1000 from m)
+    y = np.array([0,4.2,8.4,12.6,14.5,15.8,17.5,19,20.5,8.4,12.6,14.5,15.8,17.5]) * 3600 / (35000 * 100 * 100) * 1000 * 4  # "*3600 / (35000 * 100 * 100) * 1000 * 4)" converts m^3/s in mm/h
+    pumpcap_fit = np.polynomial.polynomial.Polynomial.fit(x = x, y = y, deg = 2)
+
     for z in canal_par_array:
     
         z[1] /= canal_flow_scale
@@ -169,7 +174,8 @@ def create_model_runs_list(all_kge_canal_par_df, kge, canal_flow_scale, canal_ar
                                               h_store_target = -1350, # geändert von Jonas
                                               canal_area = canal_area, 
                                               advance_pump = advance_pump, 
-                                              maxdh = maxdh)
+                                              maxdh = maxdh,
+                                              pump_par = pumpcap_fit)
         model_runs.append((x_df['h_store'], pump_cost))
         #pump_capacity_model_runs.append(pump_cost)
     

--- a/ruins/apps/extremes.py
+++ b/ruins/apps/extremes.py
@@ -163,10 +163,10 @@ def create_model_runs_list(all_kge_canal_par_df, kge, canal_flow_scale, canal_ar
          q_pump,
          x_df['h_min'], 
          x_df['flow_rec'], 
-         pump_cost) = drain_cap.storage_model(x_df,
+         pump_cost) = drain_cap.storage_model(forcing_data = x_df,
                                               canal_par = z, 
-                                              storage = 0, 
-                                              h_store = -1350, # geändert von Jonas
+                                              v_store = 0, 
+                                              h_store_target = -1350, # geändert von Jonas
                                               canal_area = canal_area, 
                                               advance_pump = advance_pump, 
                                               maxdh = maxdh)

--- a/ruins/apps/extremes.py
+++ b/ruins/apps/extremes.py
@@ -168,7 +168,8 @@ def create_model_runs_list(all_kge_canal_par_df, kge, canal_flow_scale, canal_ar
          q_pump,
          x_df['h_min'], 
          x_df['flow_rec'], 
-         pump_cost) = drain_cap.storage_model(forcing_data = x_df,
+         pump_cost,
+         store_vol) = drain_cap.storage_model(forcing_data = x_df,
                                               canal_par = z, 
                                               v_store = 0, 
                                               h_store_target = -1350, # geändert von Jonas

--- a/ruins/processing/drain_cap.py
+++ b/ruins/processing/drain_cap.py
@@ -151,4 +151,4 @@ def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400,
 
     h_store_rec = h_store_target + v_store_rec*100/canal_area
     
-    return (h_store_rec, q_pump_rec, h_min_rec, q_rec, usage_pump_rec)
+    return (h_store_rec, q_pump_rec, h_min_rec, q_rec, usage_pump_rec, v_store_rec)

--- a/ruins/processing/drain_cap.py
+++ b/ruins/processing/drain_cap.py
@@ -72,7 +72,7 @@ def drain_cap(h_tide: np.ndarray, h_store: np.ndarray, h_min: int = -2000, pump_
 
     return (q_channel, h_min, q_pump)
 
-def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400, canal_area = 4, advance_pump = 0, maxdh = 6000, pump_par = pumpcap_fit, h_min_inner = -2000):
+def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400, canal_area = 4, h_forecast_pump = 0, h_grad_pump_max = 6000, pump_par = pumpcap_fit, h_min_inner = -2000):
     """
     Storage model used for the Krummhörn region
     """
@@ -94,18 +94,18 @@ def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400,
                         canal_par = canal_par,                                     # parse canal parameters
                         h_increment = 1,                                              # increment inner water level by 1 mm steps
                         h_wind_safe = step['wig'],                             # parse wind induced gradient
-                        h_grad_pump_max = maxdh)                                     # parse maximum pump gradient
+                        h_grad_pump_max = h_grad_pump_max)                                     # parse maximum pump gradient
         # drain storage
         v_store -= cap[0]
         # compare new storage value to lower limit of storage
-        v_store = np.maximum(v_store, -advance_pump)
+        v_store = np.maximum(v_store, -h_forecast_pump)
         # save time step
         store = np.append(store, v_store)
         h_min = np.append(h_min, cap[1])
         q_pump = np.append(q_pump, cap[2])
             
         # save "power consumption" of pumps
-        if(v_store > -advance_pump):
+        if(v_store > -h_forecast_pump):
             flow = cap[0]
         else:
             flow = step['recharge']

--- a/ruins/processing/drain_cap.py
+++ b/ruins/processing/drain_cap.py
@@ -8,11 +8,11 @@ y = np.array([0,4.2,8.4,12.6,14.5,15.8,17.5,19,20.5,8.4,12.6,14.5,15.8,17.5]) * 
 pumpcap_fit = np.polynomial.polynomial.Polynomial.fit(x = x, y = y, deg = 2)
 
  
-def drain_cap(h_tide: np.ndarray, h_store: np.ndarray, h_min: int = -2000, pump_par = pumpcap_fit, channel_par: Tuple[float, float] = [1.016 , 2572.], dh: int = 50, wind_safe: int = 0, gradmax: int = 4000):
+def drain_cap(h_tide: np.ndarray, h_store: np.ndarray, h_min: int = -2000, pump_par = pumpcap_fit, canal_par: Tuple[float, float] = [1.016 , 2572.], h_increment: int = 50, h_wind_safe: int = 0, h_grad_pump_max: int = 4000):
     """
-    Find sthe maximal flow rate in a system with a pump and a canal.
+    Find the maximal flow rate in a system with a pump and a canal.
     The flow through the pump is determined by the gradient from inner to outer water level and a pump function.
-    The flow through the canal is determined by the gradient from the canal water level to the pump inner water level and a flow function.
+    The flow through the canal is determined by the gradient from the canal water level to the pump inner water level and a canal flow function.
     The inner water level is unknown and estimated within this function, but a lower limit can be set.
     
     Parameters
@@ -25,18 +25,18 @@ def drain_cap(h_tide: np.ndarray, h_store: np.ndarray, h_min: int = -2000, pump_
         the lower boundary of the inner water level
     pump_par : np.ndarray
         parameters of the pump function
-    channel_par : Tuple[float, float]
+    canal_par : Tuple[float, float]
         parameters of the canal flow function
-    dh : int
+    h_increment : int
         increment of inner water level estimation
-    wind_safe : int
+    h_wind_safe : int
         gradient from canal to inner water level, which is induced by wind and therefore not contributing to flow
-    gradmax :int
+    h_grad_pump_max :int
         maximum gradient from inner to outer water level, at which pumps shall run 
 
     Returns
     -------
-    a_channel : np.ndarry
+    q_channel : np.ndarray
         the actual maximum flow through canal and pump
     h_min : float
         the estimated inner water level
@@ -45,28 +45,27 @@ def drain_cap(h_tide: np.ndarray, h_store: np.ndarray, h_min: int = -2000, pump_
 
     """
     # set h_min to either absolute technical lower limit or maximal pump gradient 
-    h_min = np.maximum(h_min, h_tide - gradmax)
+    h_min = np.maximum(h_min, h_tide - h_grad_pump_max)
     
     pumplim = True
     
     # in case drainage ist limited by pumps, the minimum water level at knock increases until the flow is limited by channel_
-
     while pumplim:
-        if(h_tide <= h_min):
+        if(h_tide <= h_min): # if outer water level is lower then inner water level we can sluice
             q_pump = pump_par(1) # assume 1 mm gradient to pump to get some estimate - eventually sluicing is more effective
         else:
             q_pump = pump_par(h_tide - h_min)
 
-        if(((h_store - h_min) - wind_safe) <= 0):
+        if(((h_store - h_min) - h_wind_safe) <= 0):
             q_channel = 0.
         else:
-            q_channel = ((((h_store - h_min) - wind_safe)**channel_par[0])/channel_par[1])
+            q_channel = ((((h_store - h_min) - h_wind_safe)**canal_par[0])/canal_par[1])
             
         # end the loop, if h_min is set to value that q_channel is smaller than q_pump, otherwise increase h_min
         if(q_pump >= q_channel or q_channel <= 0) :
             pumplim = False
         else:
-            h_min += dh
+            h_min += h_increment
 
     # set output h_min to either technical lower limit or water level in canals
     h_min = np.minimum(h_min, h_store)
@@ -92,8 +91,13 @@ def storage_model (x, z, storage = 0, h_store = -1400, canal_area = 4, advance_p
 #        if(game['h_tide'] - (h_store + storage*100/canal_area)>maxdh):
 #            cap = [0,h_store + storage*100/canal_area, 0.0000000001]
 #        else:
-        cap = drain_cap(game['h_tide'], (h_store + storage*100/canal_area), channel_par = z, dh = 1, wind_safe = game['wig'], gradmax = maxdh)
-
+#        cap = drain_cap( , channel_par = z, dh = 1, wind_safe = game['wig'], gradmax = maxdh)
+        cap = drain_cap(h_tide = game['h_tide'],                                      # parse tidal water level
+                        h_store = (h_store + storage*100/canal_area),   # limit maximal water flow at upper canal crest
+                        canal_par = z,                                     # parse canal parameters
+                        h_increment = 1,                                              # increment inner water level by 1 mm steps
+                        h_wind_safe = game['wig'],                             # parse wind induced gradient
+                        h_grad_pump_max = maxdh)                                     # parse maximum pump gradient
         # drain storage
         storage -= cap[0]
         # compare new storage value to lower limit of storage

--- a/ruins/processing/drain_cap.py
+++ b/ruins/processing/drain_cap.py
@@ -74,7 +74,46 @@ def drain_cap(h_tide: np.ndarray, h_store: np.ndarray, h_min: int = -2000, pump_
 
 def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400, canal_area = 4, h_forecast_pump = 0, h_grad_pump_max = 6000, h_canal_max = -900, pump_par = pumpcap_fit, h_min_inner = -2000):
     """
-    Storage model used for the Krummhörn region
+    Storage model used for the Krummhoern region
+
+    Parameters
+    ----------
+    forcing_data : pd.DataFrame
+        time series forcing data of the storage model with the columns:
+         - 'recharge' the water volume [waterbalace mm] which flows into the storage
+         - 'h_tide' the outer (tidal) water level at the pumps [mm NHN]
+         - 'wig' a wind induced gradient [mm height] in the canals, which alters the flow capacity of the canals
+    canal_par : np.ndarray
+         parameters of the canal flow capacity
+    v_store : numeric
+        initial water volume [waterbalace mm] in the canals above target water level
+    h_store_target : numeric
+        target water level [mm NHN] in the canals
+    canal_area : numeric
+        share of water area on total landscape area [%]
+    h_forecast_pump : numeric
+        water level [mm height] which is substracted from target water level to allow lower canal water level before forecasted event
+    h_grad_pump_max : numeric
+        allowed maximal gradient [h_tide - h_min] for pumps, at which pumps will be turned off for their technical protection
+    pump_par : np.ndarray
+        parameters of the pump function
+    h_min : numeric
+        minimum water level height [mm NHN] at inner side of pumps
+
+    Returns
+    -------
+    h_store_rec : np.ndarray
+        water height in canals [mm NHN]
+    q_pump_rec : np.ndarray
+        possible drainage capacity by pumps [waterbalace mm]
+    h_min_rec : np.ndarray
+        evaluated lowest inner water level [mm NHN]
+    q_rec : np.ndarray
+        "real" flow [waterbalace mm], either limited by drainage capacity or pump capacity
+    usage_pump_rec : np.ndarray
+        Actually used percentage of possible pumping capacity
+    v_store_rec : np:ndarray
+        time series of water volume in storage [waterbalace mm]
     """
     store = []
     h_min = []

--- a/ruins/processing/drain_cap.py
+++ b/ruins/processing/drain_cap.py
@@ -125,6 +125,7 @@ def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400,
 
         # recharge storage
         v_store += step['recharge']
+        v_store_max_step = v_store
 
         cap = drain_cap(h_tide = step['h_tide'],                                      # parse tidal water level
                         h_store = np.min(((h_store_target + v_store*100/canal_area), h_canal_max)),   # limit maximal water flow at upper canal crest
@@ -142,14 +143,11 @@ def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400,
         v_store_rec = np.append(v_store_rec, v_store)
         h_min_rec = np.append(h_min_rec, cap[1])
         q_pump_rec = np.append(q_pump_rec, cap[2])
-            
+
+        v_flow = v_store_max_step - v_store
+        q_rec = np.append(q_rec, v_flow)
         # save "power consumption" of pumps
-        if(v_store > -h_forecast_pump):
-            flow = cap[0]
-        else:
-            flow = step['recharge']
-        q_rec = np.append(q_rec, flow)
-        usage_pump_rec = np.append(usage_pump_rec, flow/cap[2])
+        usage_pump_rec = np.append(usage_pump_rec, v_flow/cap[2])
 
     h_store_rec = h_store_target + v_store_rec*100/canal_area
     

--- a/ruins/processing/drain_cap.py
+++ b/ruins/processing/drain_cap.py
@@ -2,8 +2,9 @@ from typing import Tuple
 import numpy as np
 import pandas as pd
 
-x = np.array([7.,6.,5.,4.,3.5,3.,2,1,0,5.,4.,3.5,3.,2])
-y = np.array([0,4.2,8.4,12.6,14.5,15.8,17.5,19,20.5,8.4,12.6,14.5,15.8,17.5])
+### Define parameters of the default pumping function / pump chart
+x = np.array([7.,6.,5.,4.,3.5,3.,2,1,0,5.,4.,3.5,3.,2]) * 1000 # water gradient [mm] (by factor 1000 from m)
+y = np.array([0,4.2,8.4,12.6,14.5,15.8,17.5,19,20.5,8.4,12.6,14.5,15.8,17.5]) * 3600 / (35000 * 100 * 100) * 1000 * 4  # "*3600 / (35000 * 100 * 100) * 1000 * 4)" converts m^3/s in mm/h
 pumpcap_fit = np.polynomial.polynomial.Polynomial.fit(x = x, y = y, deg = 2)
 
  
@@ -49,13 +50,12 @@ def drain_cap(h_tide: np.ndarray, h_store: np.ndarray, h_min: int = -2000, pump_
     pumplim = True
     
     # in case drainage ist limited by pumps, the minimum water level at knock increases until the flow is limited by channel_
+
     while pumplim:
         if(h_tide <= h_min):
-            q_pump_m3 = pump_par((1)/1000) # assume 1 mm gradient to pump to get some estimate - eventually sluicing is more effective
-            q_pump = q_pump_m3 * 3600 / (35000 * 100 * 100) * 1000 * 4  # "*3600 / (35000 * 100 * 100) * 1000 * 4)" converts m^3/s in mm/h
+            q_pump = pump_par(1) # assume 1 mm gradient to pump to get some estimate - eventually sluicing is more effective
         else:
-            q_pump_m3 = pump_par((h_tide - h_min)/1000)
-            q_pump = q_pump_m3 *3600 / (35000 * 100 * 100) * 1000 * 4  # "*3600 / (35000 * 100 * 100) * 1000 * 4)" converts m^3/s in mm/h
+            q_pump = pump_par(h_tide - h_min)
 
         if(((h_store - h_min) - wind_safe) <= 0):
             q_channel = 0.

--- a/ruins/processing/drain_cap.py
+++ b/ruins/processing/drain_cap.py
@@ -82,21 +82,16 @@ def storage_model (x, z, storage = 0, h_store = -1400, canal_area = 4, advance_p
     pump_cost = []
     flow_rec = []
     
-    for idx, game in x.iterrows():
+    for step_id, step in x.iterrows():
 
         # recharge storage
-        storage += game['recharge']
+        storage += step['recharge']
 
-        # get drain_cap, do not pump if dh > than specified limit
-#        if(game['h_tide'] - (h_store + storage*100/canal_area)>maxdh):
-#            cap = [0,h_store + storage*100/canal_area, 0.0000000001]
-#        else:
-#        cap = drain_cap( , channel_par = z, dh = 1, wind_safe = game['wig'], gradmax = maxdh)
-        cap = drain_cap(h_tide = game['h_tide'],                                      # parse tidal water level
-                        h_store = (h_store + storage*100/canal_area),   # limit maximal water flow at upper canal crest
+        cap = drain_cap(h_tide = step['h_tide'],                                      # parse tidal water level
+                        h_store = (h_store + storage*100/canal_area),   
                         canal_par = z,                                     # parse canal parameters
                         h_increment = 1,                                              # increment inner water level by 1 mm steps
-                        h_wind_safe = game['wig'],                             # parse wind induced gradient
+                        h_wind_safe = step['wig'],                             # parse wind induced gradient
                         h_grad_pump_max = maxdh)                                     # parse maximum pump gradient
         # drain storage
         storage -= cap[0]
@@ -111,7 +106,7 @@ def storage_model (x, z, storage = 0, h_store = -1400, canal_area = 4, advance_p
         if(storage > -advance_pump):
             flow = cap[0]
         else:
-            flow = game['recharge']
+            flow = step['recharge']
         flow_rec = np.append(flow_rec, flow)
         pump_cost = np.append(pump_cost, flow/cap[2])
 

--- a/ruins/processing/drain_cap.py
+++ b/ruins/processing/drain_cap.py
@@ -72,7 +72,7 @@ def drain_cap(h_tide: np.ndarray, h_store: np.ndarray, h_min: int = -2000, pump_
 
     return (q_channel, h_min, q_pump)
 
-def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400, canal_area = 4, h_forecast_pump = 0, h_grad_pump_max = 6000, pump_par = pumpcap_fit, h_min_inner = -2000):
+def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400, canal_area = 4, h_forecast_pump = 0, h_grad_pump_max = 6000, h_canal_max = -900, pump_par = pumpcap_fit, h_min_inner = -2000):
     """
     Storage model used for the Krummhörn region
     """
@@ -88,7 +88,7 @@ def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400,
         v_store += step['recharge']
 
         cap = drain_cap(h_tide = step['h_tide'],                                      # parse tidal water level
-                        h_store = (h_store_target + v_store*100/canal_area),
+                        h_store = np.min(((h_store_target + v_store*100/canal_area), h_canal_max)),   # limit maximal water flow at upper canal crest
                         h_min = h_min_inner,                                     # parse lowest inner water level
                         pump_par = pump_par,                                     # parse pump parameters
                         canal_par = canal_par,                                     # parse canal parameters

--- a/ruins/processing/drain_cap.py
+++ b/ruins/processing/drain_cap.py
@@ -138,7 +138,7 @@ def storage_model (forcing_data, canal_par, v_store = 0, h_store_target = -1400,
         # drain storage
         v_store -= cap[0]
         # compare new storage value to lower limit of storage
-        v_store = np.maximum(v_store, -h_forecast_pump)
+        v_store = np.maximum(v_store, -h_forecast_pump/100*canal_area)
         # save time step
         v_store_rec = np.append(v_store_rec, v_store)
         h_min_rec = np.append(h_min_rec, cap[1])

--- a/ruins/processing/drain_cap.py
+++ b/ruins/processing/drain_cap.py
@@ -72,7 +72,7 @@ def drain_cap(h_tide: np.ndarray, h_store: np.ndarray, h_min: int = -2000, pump_
 
     return (q_channel, h_min, q_pump)
 
-def storage_model (x, z, storage = 0, h_store = -1400, canal_area = 4, advance_pump = 0, maxdh = 6000):
+def storage_model (x, canal_par, storage = 0, h_store = -1400, canal_area = 4, advance_pump = 0, maxdh = 6000, pump_par = pumpcap_fit, h_min_inner = -2000):
     """
     Storage model used for the Krummhörn region
     """
@@ -89,7 +89,9 @@ def storage_model (x, z, storage = 0, h_store = -1400, canal_area = 4, advance_p
 
         cap = drain_cap(h_tide = step['h_tide'],                                      # parse tidal water level
                         h_store = (h_store + storage*100/canal_area),   
-                        canal_par = z,                                     # parse canal parameters
+                        h_min = h_min_inner,                                     # parse lowest inner water level
+                        pump_par = pump_par,                                     # parse pump parameters
+                        canal_par = canal_par,                                     # parse canal parameters
                         h_increment = 1,                                              # increment inner water level by 1 mm steps
                         h_wind_safe = step['wig'],                             # parse wind induced gradient
                         h_grad_pump_max = maxdh)                                     # parse maximum pump gradient


### PR DESCRIPTION
Vorschlag zur Verwendung des NC-Files

Mit der Version im Pull request hat das Laden und Verwenden des NC-Files anstelle der CSVs bei mir funktioniert.
Das Konvertieren in pd.series und dann das anschliesende wiederzusammenfügen in der Funktion create_initial_x_dataset() ist vmtl. nicht die eleganteste Lösung, ansonsten funktionieren aber die anschliesenden Modelle / Visualisierung nicht mehr sauber.